### PR TITLE
Fix behaviour of CALL.SIL opcode

### DIFF
--- a/src/opcode_jumps.rs
+++ b/src/opcode_jumps.rs
@@ -167,7 +167,7 @@ pub fn build_call() -> Opcode {
     Opcode {
         name: "CALL nn".to_string(),
         action: Box::new(move |env: &mut Environment| {
-            let address = env.advance_immediate_16mbase_or_24();
+            let address = env.advance_immediate16or24();
             handle_call_size_prefix(env);
             env.state.set_pc(address);
         })


### PR DESCRIPTION
CALL.SIL does not exhibit the same behaviour as, for example, LD.SIL A,(Mmn), in that it will not replace the top 8 bits of the 24-bit address with MBASE.

Update build_call() to use env.advance_immediate16or24() instead of env.advance_immediate_16mbase_or_24() in order to ensure the correct behaviour.

